### PR TITLE
fix: reduce health manager log level for unkown type for key

### DIFF
--- a/exporter/health_manager.go
+++ b/exporter/health_manager.go
@@ -135,7 +135,7 @@ func (hm *HealthManager) collectMetricsDeployment(ch chan<- prometheus.Metric, p
 			// recursively get lower level metrics
 			ret = ret && hm.collectMetricsDeployment(ch, newPath, v)
 		default:
-			level.Error(hm.logger).Log("msg", "unknown type for key", "key", key, "path", path)
+			level.Debug(hm.logger).Log("msg", "unknown type for key", "key", key, "path", path)
 		}
 	}
 	level.Debug(hm.logger).Log("num_red", num_red, "num_yellow", num_yellow)


### PR DESCRIPTION
## Problem
Health metrics collection logs spurious errors for legitimate Splunk API metadata fields (display_name, version, peer_version, etc.), polluting logs on every scrape.

## Solution
Changed log level from Error to Debug for unknown field types in collectMetricsDeployment, since these are expected metadata fields, not actual errors.

## Testing
- Metrics continue to be collected correctly
- No more error logs for metadata fields
- Debug info still available with --log.level=debug